### PR TITLE
Fix percentage & cleanup

### DIFF
--- a/argon-status.py
+++ b/argon-status.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python3
+
+import sys
+import os
+import time
+import math
+#sys.path.append( "/etc/argon/")
+from argonsysinfo import *
+
+#
+# Display CPU utilization
+# 
+print( "CPU Utilization:" )
+cpulist = argonsysinfo_listcpuusage()
+maxcpu = 4
+while maxcpu > 0 and len(cpulist) > 0:
+    curline = ""
+    item = cpulist.pop(0)
+    curline = "    " + item["title"] + ": " + str(item["value"]) + "%"
+    print( curline )
+    maxcpu = maxcpu - 1
+
+#
+# Display Usage
+#
+print( "Storage Usage:" )
+hddlist = argonsysinfo_listhddusage()
+for dev in hddlist:
+    total = hddlist[dev]['total']
+    used  = hddlist[dev]['used']
+    percent = hddlist[dev]['percent']
+    print( "    Device : " + dev + " Total : " + argonsysinfo_kbstr(total) + " Used: " + argonsysinfo_kbstr(used) + " Usage: " + str(percent) + "%" ) 
+
+#
+# Display RAID
+#
+print( "RAID Arrays:" )
+raidinfo = argonsysinfo_listraid()
+raidlist = raidinfo['raidlist']
+hddlist  = raidinfo['hddlist']
+while len(raidlist) > 0:
+    item = raidlist.pop(0)
+    rebuild = ""
+    if len(item['info']['resync']) > 0:
+        rebuild = " Rebuild: " + item['info']['resync']
+    stateArray = item['info']['state'].split( ", " )
+    if len(stateArray) == 1:
+        state = stateArray[0]
+    if len(stateArray) == 2:
+        state = stateArray[1]
+    if len(stateArray) >= 3:
+        state = stateArray[2]
+    print( "    Device: " + item['title'] + " Type: " + item['info']['raidtype'].upper() + " State: " + state + " Size: " +argonsysinfo_kbstr(item['info']['size'] ) + rebuild )
+
+#print( "Drives used in RAID:" )
+#print( hddlist )
+#
+# Display memory usage
+#
+tmp = argonsysinfo_getram()
+print( "Memory:")
+print( "    Total: " + tmp[1] )
+print( "    Free : " + tmp[0] )
+
+#
+# Display temp
+#
+tmp = argonsysinfo_gettemp()
+ctemp = str(tmp)
+ftemp = str(32 + (9*tmp)/5)
+if len(ctemp ) > 4:
+    ctemp = ctemp[0:4]
+if len(ftemp) > 5:
+    ftemp = ftemp[0:5]
+
+print( "Temp: " )
+print( "    " + str(ctemp) + "C")
+print( "    " + str(ftemp) + "F")
+
+#
+# Display IP address
+#
+tmp = argonsysinfo_getipList()
+print( "IP Address : " )
+for item in tmp:
+    print( "    " + item[0] + ": " + item[1] )
+

--- a/argon-status.py
+++ b/argon-status.py
@@ -4,7 +4,7 @@ import sys
 import os
 import time
 import math
-#sys.path.append( "/etc/argon/")
+sys.path.append( "/etc/argon/")
 from argonsysinfo import *
 
 #

--- a/argoneon.sh
+++ b/argoneon.sh
@@ -200,6 +200,7 @@ sudo chmod 755 $shutdownscript
 # Argon Status script
 sudo curl -L $ARGONDOWNLOADSERVER/argon-status.sh -o $statusscript --silent
 sudo chmod 755 $statusscript
+sudo ln -s $statusscript /usr/bin/argon-status
 
 # Argon Config Script
 if [ -f $configscript ]; then

--- a/argoneon.sh
+++ b/argoneon.sh
@@ -10,6 +10,7 @@ INSTALLATIONFOLDER=/etc/argon
 
 uninstallscript=$INSTALLATIONFOLDER/argon-uninstall.sh
 shutdownscript=/lib/systemd/system-shutdown/argon-shutdown.sh
+statusscript=/$INSTALLATIONFOLDER/argon-status.sh
 configscript=$INSTALLATIONFOLDER/argon-config
 
 setupmode="Setup"
@@ -195,6 +196,10 @@ sudo chmod 755 $uninstallscript
 # Argon Shutdown script
 sudo curl -L $ARGONDOWNLOADSERVER/argon-shutdown.sh -o $shutdownscript --silent
 sudo chmod 755 $shutdownscript
+
+# Argon Status script
+sudo curl -L $ARGONDOWNLOADSERVER/argon-status.sh -o $statusscript --silent
+sudo chmod 755 $statusscript
 
 # Argon Config Script
 if [ -f $configscript ]; then

--- a/argononed.py
+++ b/argononed.py
@@ -279,7 +279,7 @@ def display_loop(readq):
                 try:
                     tmpobj = argonsysinfo_listhddusage()
                     for curdev in tmpobj:
-                        curlist.append({"title": curdev, "value": argonsysinfo_kbstr(tmpobj[curdev]['total']), "usage": int(100*tmpobj[curdev]['used']/tmpobj[curdev]['total']) })
+                        curlist.append({"title": curdev, "value": argonsysinfo_kbstr(tmpobj[curdev]['total']), "usage": int(tmpobj[curdev]['percent']) })
                     #curlist = argonsysinfo_liststoragetotal()
                 except:
                     curlist = []

--- a/argonsysinfo.py
+++ b/argonsysinfo.py
@@ -225,10 +225,11 @@ def argonsysinfo_listhddusage():
                   curdev = curdev[0:-1]
               else:
                   curdev = curdev[0:-2]
+            percent=infolist[4].split("%")[0]
             if curdev in outputobj:
-                outputobj[curdev] = {"used":outputobj[curdev]['used']+int(infolist[2]), "total":outputobj[curdev]['total']+int(infolist[1])}
+                outputobj[curdev] = {"used":outputobj[curdev]['used']+int(infolist[2]), "total":outputobj[curdev]['total']+int(infolist[1]), "percent":outputobj[curdev]['percent']+int(percent)}
             else:
-                outputobj[curdev] = {"used":int(infolist[2]), "total":int(infolist[1])}
+                outputobj[curdev] = {"used":int(infolist[2]), "total":int(infolist[1]), "percent":int(percent)}
 
     return outputobj
 
@@ -307,7 +308,8 @@ def argonsysinfo_getraiddetail(devname):
     failed = 0
     spare = 0
     resync = ""
-    tmp = os.popen('mdadm -D /dev/'+devname).read()
+    hddlist =[]
+    tmp = os.popen('sudo mdadm -D /dev/'+devname).read()
     alllines = tmp.split("\n")
 
     for temp in alllines:
@@ -341,5 +343,11 @@ def argonsysinfo_getraiddetail(devname):
                 spare = infolist[1]
             elif infolist[0].lower() == "rebuild status":
                 resync = infolist[1]
-    return {"state": state, "raidtype": raidtype, "size": int(size), "used": int(used), "devices": int(total), "active": int(active), "working": int(working), "failed": int(failed), "spare": int(spare), "resync": resync}
+            elif infolist[0].lower() == "resync status":
+                resync = infolist[1]
+        elif len(infolist) > 0:
+            infolist = temp.split(" ")
+            if len(infolist) == 7:
+                hddlist.append(infolist[6])
+    return {"state": state, "raidtype": raidtype, "size": int(size), "used": int(used), "devices": int(total), "active": int(active), "working": int(working), "failed": int(failed), "spare": int(spare), "resync": resync, "hddlist":hddlist}
 


### PR DESCRIPTION
1) Fixup drive use percentage to it matches output from df, it always seemed to be off a percentage even if roundup was enabled
2) add argon-status command so we can check on the status of the system (i.e. see  a similar display to the OLED display) remotely.