### PR TITLE
ensure python3-psutil is installed

### DIFF
--- a/argoneon.sh
+++ b/argoneon.sh
@@ -43,7 +43,7 @@ grep -q -F 'Raspbian' /etc/os-release &> /dev/null
 if [ $? -eq 0 ]
 then
 	CHECKPLATFORM="Raspbian"
-	pkglist=(raspi-gpio python3-rpi.gpio python3-smbus i2c-tools)	
+	pkglist=(raspi-gpio python3-rpi.gpio python3-smbus i2c-tools python3-psutil)
 else
 	# Ubuntu has serial and i2c enabled
 	pkglist=(python3-rpi.gpio python3-smbus i2c-tools)


### PR DESCRIPTION
on a lite 64bit bullseye installation argonond.service was failing to
start with:

```
$ python3 /etc/argon/argononed.py SERVICE
Traceback (most recent call last):
  File "/etc/argon/argononed.py", line 33, in <module>
    from argonsysinfo import *
  File "/etc/argon/argonsysinfo.py", line 10, in <module>
    import psutil
ModuleNotFoundError: No module named 'psutil'
$
```

this adds the installation of this module to the setup script