### PR TITLE
fix fan speed in argon-status

### DIFF
--- a/argononed.py
+++ b/argononed.py
@@ -194,7 +194,7 @@ speed = Path('/tmp/fanspeed.txt')
 
 def getCurrentFanSpeed():
     try:
-        return int(speed.read_text())
+        return int(float(speed.read_text()))
     except FileNotFoundError:
         return None
 
@@ -241,7 +241,7 @@ def setFanSpeed (overrideSpeed : int = None, instantaneous : bool = True):
                 # Spin up to prevent issues on older units
                 bus.write_byte(ADDR_FAN,100)
                 time.sleep(1)
-            bus.write_byte(ADDR_FAN,newspeed)
+            bus.write_byte(ADDR_FAN,int(newspeed))
         except IOError:
             return prevspeed
     writeSpeed (newspeed)


### PR DESCRIPTION
Fixes  #32 

error from sys logs:

`Dec 30 21:19:58 argoneon sudo[60901]: pam_unix(sudo:session): session closed for user root
Dec 30 21:20:00 argoneon python3[60906]: Exception in thread Thread-2 (temp_check):
Dec 30 21:20:00 argoneon python3[60906]: Traceback (most recent call last):
Dec 30 21:20:00 argoneon python3[60906]:   File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
Dec 30 21:20:00 argoneon python3[60906]:     self.run()
Dec 30 21:20:00 argoneon python3[60906]:   File "/usr/lib/python3.10/threading.py", line 953, in run
Dec 30 21:20:00 argoneon python3[60906]:     self._target(*self._args, **self._kwargs)
Dec 30 21:20:00 argoneon python3[60906]:   File "/etc/argon/argononed.py", line 252, in temp_check
Dec 30 21:20:00 argoneon python3[60906]:     setFanSpeed (instantaneous = False)
Dec 30 21:20:00 argoneon python3[60906]:   File "/etc/argon/argononed.py", line 244, in setFanSpeed
Dec 30 21:20:00 argoneon python3[60906]:     bus.write_byte(ADDR_FAN,newspeed)
Dec 30 21:20:00 argoneon python3[60906]: TypeError: 'float' object cannot be interpreted as an integer`

Fixing above error then created this error due to converting string rep of float straight to int:

`Traceback (most recent call last):
  File "/usr/bin/argon-status", line 59, in <module>
    printTable({"Speed %" : getCurrentFanSpeed()}
  File "/etc/argon/argononed.py", line 197, in getCurrentFanSpeed
    return int(speed.read_text())
ValueError: invalid literal for int() with base 10: '30.0'`

