### PR TITLE
get_fanspeed was not returning the proper value

### DIFF
--- a/argononed.py
+++ b/argononed.py
@@ -91,7 +91,7 @@ def get_fanspeed(tempval, configlist):
     if len(configlist) > 0:
         for k in configlist.keys():
             if tempval >= k:
-                retval=k
+                retval=configlist[k]
                 break
         #retval = configlist[max([k for k in configlist.keys() if tempval >= k])]
     return retval


### PR DESCRIPTION
get_fanspeed was returning the temperature of the device as a fanspeed, this is why we were getting floating point values were integers were supposed to be delivered.  Fixed the issue.

Also added the ability to get the temperature of my NVME device, not sure if it will work for others.