### PR TITLE
49 support ubuntu 2304

### DIFF
--- a/argoneon.sh
+++ b/argoneon.sh
@@ -361,3 +361,7 @@ $versioninfoscript
 echo 
 echo "Use '$configcmd' to configure device"
 echo
+
+echo
+echo "Make sure that the I2C bus is enabled, use raspi-config and change the setting under Interface Options"
+echo

--- a/argoneon.sh
+++ b/argoneon.sh
@@ -65,6 +65,10 @@ then
     then
         echo "Installing on Ubuntu version 22.04"
         pkglist=(python3-lgpio python3-rpi.gpio python3-smbus i2c-tools python3-psutil curl smartmontools)
+    elif [ "${version}" == "23.04" ]
+    then
+	echo "Installing on Ubuntu version 23.04"
+	pkglist=(python3-lgpio python3-rpi.gpio python3-smbus i2c-tools python3-psutil curl smartmontools raspi-config)
     else
         echo "Unsupported Ubuntu verison: " ${pretty_name}
         exit


### PR DESCRIPTION
Added support for Ubuntu 23.04.

Looks like an install of 23.04 can disable the I2C bus, so also installing raspi-config.  User can run raspi-config to use the Interface Option menu and enable I2C and SPI

