### PR TITLE
Modify the default settings for screen saver.

### DIFF
--- a/argonconfig.py
+++ b/argonconfig.py
@@ -15,9 +15,9 @@ def setOLEDDefaults(config):
         config['OLED'] = {}
 
     if not 'screenduration' in config['OLED'].keys():
-        config['OLED']['screenduration'] = '30';
+        config['OLED']['screenduration'] = '40';
     if not 'screensaver' in config['OLED'].keys():
-        config['OLED']['screensaver'] = '120'
+        config['OLED']['screensaver'] = '30'
     if not 'screenlist' in config['OLED'].keys():
         config['OLED']['screenlist'] = 'clock cpu storage bandwidth raid ram temp ip'
     if not 'enabled' in config['OLED'].keys():


### PR DESCRIPTION
For the screensaver to work the value of "screensaver" in the configuration file must be less than the value of "screenduration", the difference is the amount of time the data is displayed on the screen.